### PR TITLE
fixed save chart select text...it was previously opposite - it would …

### DIFF
--- a/deforestation-dashboard/src/components/Country.js
+++ b/deforestation-dashboard/src/components/Country.js
@@ -113,7 +113,7 @@ export default function Country(props) {
               addItem(props["code"])
               setSelected(true)
             }}>
-            {selected ? "Save to My Charts" : "Saved to My Charts"}
+            {selected ? "Saved to My Charts" : "Save to My Charts"}
 
           </Button>
           <Button


### PR DESCRIPTION
…say saved before it was saved

co-authored by: Justine Lai <justine.lai@gmail.com>